### PR TITLE
Handle errors

### DIFF
--- a/lib/ncua.rb
+++ b/lib/ncua.rb
@@ -6,6 +6,7 @@ require 'ncua/credit_union/record'
 require 'ncua/credit_union/office'
 require 'ncua/credit_union/details'
 require 'ncua/credit_union/scraper'
+require 'ncua/credit_union/details_client'
 
 module NCUA
   def self.find_office_by_address(address, opts={radius: 100})

--- a/lib/ncua/credit_union/details_client.rb
+++ b/lib/ncua/credit_union/details_client.rb
@@ -1,11 +1,19 @@
 module NCUA
   module CreditUnion
+    class ServerError < ::StandardError; end
     class DetailsClient
       include HTTParty
 
       base_uri 'http://mapping.ncua.gov'
       def get_details(charter_number)
         response = execute_query(charter_number)
+
+        case response.code
+        when 200...300
+          response
+        when 500...600
+          raise ServerError
+        end
       end
 
       private
@@ -20,6 +28,5 @@ module NCUA
         })
       end
     end
-    class RecordNotFoundError < StandardError; end
   end
 end

--- a/lib/ncua/credit_union/details_client.rb
+++ b/lib/ncua/credit_union/details_client.rb
@@ -6,6 +6,10 @@ module NCUA
 
       base_uri 'http://mapping.ncua.gov'
       def get_details(charter_number)
+        if charter_number.nil?
+          raise ArgumentError, "charter number cannot be nil"
+        end
+
         response = execute_query(charter_number)
 
         case response.code

--- a/lib/ncua/credit_union/details_client.rb
+++ b/lib/ncua/credit_union/details_client.rb
@@ -1,0 +1,25 @@
+module NCUA
+  module CreditUnion
+    class DetailsClient
+      include HTTParty
+
+      base_uri 'http://mapping.ncua.gov'
+      def get_details(charter_number)
+        response = execute_query(charter_number)
+      end
+
+      private
+
+      def endpoint
+        '/SingleResult.aspx'
+      end
+
+      def execute_query(charter_number)
+        self.class.get(endpoint, query: {
+          "ID" => charter_number
+        })
+      end
+    end
+    class RecordNotFoundError < StandardError; end
+  end
+end

--- a/lib/ncua/credit_union/scraper.rb
+++ b/lib/ncua/credit_union/scraper.rb
@@ -2,9 +2,6 @@ module NCUA
   module CreditUnion
     class Scraper
       #This bit is as brittle as glass, as coupled as conjoined twins, and as stinky as bad cheese
-      include HTTParty
-
-      base_uri 'http://mapping.ncua.gov'
       def initialize(charter_number)
         @charter_number = charter_number
       end
@@ -36,13 +33,7 @@ module NCUA
       end
 
       def request
-        self.class.get(endpoint, query: {
-          "ID" => @charter_number
-        })
-      end
-
-      def endpoint
-        '/SingleResult.aspx'
+        @request ||= DetailsClient.get_details(@charter_number)
       end
     end
   end

--- a/spec/ncua/credit_union/details_client_spec.rb
+++ b/spec/ncua/credit_union/details_client_spec.rb
@@ -23,4 +23,12 @@ describe NCUA::CreditUnion::DetailsClient do
       end
     end
   end
+
+  describe 'nil charter numbers' do
+    context 'when the charter number is nil' do
+      it 'raises an argument error' do
+        expect { details_client.get_details(nil) }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/ncua/credit_union/details_client_spec.rb
+++ b/spec/ncua/credit_union/details_client_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe NCUA::CreditUnion::DetailsClient do
+  let(:details_client) { NCUA::CreditUnion::DetailsClient.new }
+  describe 'response code handling' do
+    let(:valid_charter_number) { 9009 }
+    let(:invalid_charter_number) { 234434 }
+    let(:good_response) { double("response", code: 200) }
+    let(:error_response) { double("response", code: 500) }
+    context 'when the response is 200' do
+      it 'does not raise an exception' do
+        allow(details_client).to receive(:execute_query).and_return(good_response)
+
+        expect { details_client.get_details(valid_charter_number) }.not_to raise_error(NCUA::CreditUnion::ServerError)
+      end
+    end
+
+    context 'when the response is 500' do
+      it 'raises an NCUA::CreditUnion::RecordNotFound exception' do
+        allow(details_client).to receive(:execute_query).and_return(error_response)
+
+        expect { details_client.get_details(valid_charter_number) }.to raise_error(NCUA::CreditUnion::ServerError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR handles possible error cases when getting credit union details.

If the NCUA returns a 500 for a credit union details page, return a RecordNotFoundError.

If the user passes in `nil` as a charter number, then blow up with an ArgumentError. The NCUA won't blow up, but it won't return any meaningful data. 
