### PR TITLE
Handle empty string argument errors

### DIFF
--- a/lib/ncua/credit_union/details_client.rb
+++ b/lib/ncua/credit_union/details_client.rb
@@ -6,8 +6,9 @@ module NCUA
 
       base_uri 'http://mapping.ncua.gov'
       def get_details(charter_number)
-        if charter_number.nil?
-          raise ArgumentError, "charter number cannot be nil"
+        charter_number = charter_number.to_s.strip
+        if charter_number.empty?
+          raise ArgumentError, "charter number cannot be nil or empty string"
         end
 
         response = execute_query(charter_number)

--- a/lib/ncua/version.rb
+++ b/lib/ncua/version.rb
@@ -1,3 +1,3 @@
 module NCUA
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/spec/ncua/credit_union/details_client_spec.rb
+++ b/spec/ncua/credit_union/details_client_spec.rb
@@ -24,10 +24,16 @@ describe NCUA::CreditUnion::DetailsClient do
     end
   end
 
-  describe 'nil charter numbers' do
+  describe 'bad charter numbers' do
     context 'when the charter number is nil' do
       it 'raises an argument error' do
         expect { details_client.get_details(nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the charter number is an empty string' do
+      it 'raises an argument error' do
+        expect { details_client.get_details("") }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
The NCUA won't respond with an error code if either `nil` or `""` is passed in as an argument to its details page. [See for yourself](http://mapping.ncua.gov/SingleResult.aspx?ID=). When we scrape that page, it tries to pass a bunch of empty strings into the attributes hash for a `CreditUnion::Details` object. When getter methods are called, they sometimes try to handle an empty string in ways that blow up, e.g. trying to call `Date.strptime` on `""`. 

We could build these checks into the various `field` calls within `CreditUnion::Details` so that if those values are validly blank, then we handle them gracefully. 

But for now, the `DetailsClient` should raise an `ArgumentError` if passed an empty string.
