### PR TITLE
Add spec for whitespace NCUA IDs for fetching details.

### DIFF
--- a/spec/ncua/credit_union/details_client_spec.rb
+++ b/spec/ncua/credit_union/details_client_spec.rb
@@ -33,7 +33,7 @@ describe NCUA::CreditUnion::DetailsClient do
     end
   end
 
-  describe 'bad charter numbers' do
+  describe 'blank charter numbers' do
     context 'when the charter number is nil' do
       it 'raises an argument error' do
         expect { details_client.get_details(nil) }.to raise_error(ArgumentError)
@@ -43,6 +43,12 @@ describe NCUA::CreditUnion::DetailsClient do
     context 'when the charter number is an empty string' do
       it 'raises an argument error' do
         expect { details_client.get_details("") }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the charter number is a whitespace string' do
+      it 'raises an argument error' do
+        expect { details_client.get_details(" \t   \n   ") }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
As I was looking over #2, I noticed a spec I could add. So I did.
